### PR TITLE
Fix bug with build system.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -9,7 +9,6 @@ AM_CPPFLAGS = \
 
 AM_CFLAGS = ${my_CFLAGS} -g
 
-AM_LDFLAGS = -lbios -lm src/libvat.a
 
 PC_SED = \
 	$(AM_V_GEN)$(MKDIR_P) $(dir $@) && $(SED) \
@@ -43,10 +42,11 @@ bin_PROGRAMS = \
 	src/vcfModifyHeader \
 	src/vatson
 
-src_vcf2images_LDADD = -lgd -lpng -lz -lfreetype
+LDADD = -lbios -lm src/libvat.a
+src_vcf2images_LDADD = -lbios -lm src/libvat.a -lgd -lpng -lz -lfreetype
 
 # Web
-all-local: web master
+all-local: web
 
 web:
 	@echo '  GEN    web/vat.conf'

--- a/src/vat.pc.in
+++ b/src/vat.pc.in
@@ -1,0 +1,12 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: @PACKAGE_NAME@
+Description: Variant annotation tool
+Version: @PACKAGE_VERSION@
+URL: @PACKAGE_URL@
+Requires.private: gsl
+Cflags = -I@{includedir}
+Libs: -L@{libdir}


### PR DESCRIPTION
The new nonrecursive make had a bug with linker flags. LDADD needed to be used to include the VAT convenience library rather than LDFLAGS.
